### PR TITLE
Add the ability to specify the order of fields or columns

### DIFF
--- a/gallery/views/gallery_template.html
+++ b/gallery/views/gallery_template.html
@@ -48,7 +48,7 @@
         <a href="/searchbar">Search bar</a><br/>
         <a href="/searchresults">Search results</a><br/>
         <a href="/statusbadge">Status badge</a><br/>
-        <a href="/table">tables</a>
+        <a href="/table">Tables</a><br/>
         <a href="/textarea">Textarea</a><br/>
         <a href="/textbox">Textbox</a><br/>
       </nav>

--- a/gallery/views/table.html
+++ b/gallery/views/table.html
@@ -39,7 +39,7 @@
     </div>
     <h2 class="heading-large">Readonly key values</h2>
     <div class="example">
-      {{ trade.keyvaluetable(company, readonly=true, labels=companyLabels) }}
+      {{ trade.keyvaluetable(company, readonly=true, labels=companyLabels, keyorder=['registeredName', 'tradingName', 'type', 'sector', 'subSector']) }}
     </div>
     <div class="html">
         <h3 class="heading-medium">HTML</h3>
@@ -103,6 +103,11 @@
           <td>N</td>
           <td>A id value to add to the table tag</td>
         </tr>
+        <tr>
+          <td>keyorder</td>
+          <td>N</td>
+          <td>An array of 'keys', to allow the developer to specify the order fields appear</td>
+        </tr>
         </tbody>
       </table>
     </div>
@@ -113,7 +118,7 @@
       further enhance that view so that the user can click on a table heading and sort the table by that column. If you miss out the sortable classes on the markup
       then the table will display ok, it just wont be enhanced to allow sorting.</p>
     <div class="example">
-      {{ trade.datatable(contacts, headings=contactLabels) }}
+      {{ trade.datatable(contacts, headings=contactLabels, columnorder=['name', 'email', 'phone', 'role']) }}
     </div>
     <div class="html">
       <h3 class="heading-medium">HTML</h3>
@@ -191,6 +196,11 @@
           <td>id</td>
           <td>N</td>
           <td>A id value to add to the table tag</td>
+        </tr>
+        <tr>
+          <td>columnorder</td>
+          <td>N</td>
+          <td>An array of 'keys', to allow the developer to specify the order columns appear</td>
         </tr>
         </tbody>
       </table>

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -9,7 +9,6 @@
 
       @include media(tablet) {
         width: 30%;
-        white-space: nowrap;
       }
     }
 

--- a/src/components/table/table.html
+++ b/src/components/table/table.html
@@ -20,10 +20,12 @@
         {% set forLabel = key %}
       {% endif %}
 
-      <tr>
-        <th>{{ forLabel }}</th>
-        <td>{{ data[key] }}</td>
-      </tr>
+      {% if data[key] or data[key] == '' %}
+        <tr>
+          <th>{{ forLabel }}</th>
+          <td>{{ data[key] }}</td>
+        </tr>
+      {% endif %}
     {% endfor %}
   {% else %}
 

--- a/src/components/table/table.html
+++ b/src/components/table/table.html
@@ -1,4 +1,4 @@
-{% macro keyvaluetable(data, readonly, stripey, labels, class="", id) %}
+{% macro keyvaluetable(data, readonly, stripey, labels, class="", id, keyorder) %}
 
 {% set className = "table--key-value " + class %}
 
@@ -10,28 +10,42 @@
   {% set className = className + ' table--readonly' %}
 {% endif %}
 
-
 <table class="{{ className }}" id="{{ id }}">
   <tbody>
-  {% for key, value in data %}
+  {% if keyorder %}
+    {% for key in keyorder %}
+      {% if labels and labels[key] %}
+        {% set forLabel = labels[key] %}
+      {% else %}
+        {% set forLabel = key %}
+      {% endif %}
 
-    {% if labels and labels[key] %}
-      {% set forLabel = labels[key] %}
-    {% else %}
-      {% set forLabel = key %}
-    {% endif %}
+      <tr>
+        <th>{{ forLabel }}</th>
+        <td>{{ data[key] }}</td>
+      </tr>
+    {% endfor %}
+  {% else %}
 
-    <tr>
-      <th>{{ forLabel }}</th>
-      <td>{{ value }}</td>
-    </tr>
-  {% endfor %}
+    {% for key, value in data %}
+      {% if labels and labels[key] %}
+        {% set forLabel = labels[key] %}
+      {% else %}
+        {% set forLabel = key %}
+      {% endif %}
+
+      <tr>
+        <th>{{ forLabel }}</th>
+        <td>{{ value }}</td>
+      </tr>
+    {% endfor %}
+  {% endif %}
   </tbody>
 </table>
 
 {% endmacro %}
 
-{% macro datatable(data, stripey=false, headings, class="", id) %}
+{% macro datatable(data, stripey, headings, class="", id, columnorder) %}
   {% set className = "table--data table--sortable js-table--sortable " + class %}
 
   {% if stripey == true %}
@@ -42,23 +56,41 @@
   <table class="{{ className }}" id="{{ id }}">
     <thead>
       <tr>
-        {% for key, value in headData %}
-          <th data-key="{{ key }}">
-            {% if headings and headings[key] %}
-              {{ headings[key] }}
-            {% else %}
-              {{ key }}
-            {% endif %}
-          </th>
-        {% endfor %}
+        {% if not columnorder %}
+          {% for key, value in headData %}
+            <th data-key="{{ key }}">
+              {% if headings and headings[key] %}
+                {{ headings[key] }}
+              {% else %}
+                {{ key }}
+              {% endif %}
+            </th>
+          {% endfor %}
+        {% else %}
+          {% for key in columnorder %}
+            <th data-key="{{ key }}">
+              {% if headings and headings[key] %}
+                {{ headings[key] }}
+              {% else %}
+                {{ key }}
+              {% endif %}
+            </th>
+          {% endfor %}
+        {% endif %}
       </tr>
     </thead>
     <tbody>
       {% for record in data %}
         <tr>
-          {% for key, value in record %}
-            <td>{{ value }}</td>
-          {% endfor %}
+          {% if not columnorder %}
+            {% for key, value in record %}
+              <td>{{ value }}</td>
+            {% endfor %}
+          {% else %}
+            {% for key in columnorder %}
+              <td>{{ record[key] }}</td>
+            {% endfor %}
+          {% endif %}
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
There are times when you want to set the order that fields are displayed, regardless of how the object data is ordered.