### PR TITLE
Simplify header to remove crown and fix position and spacing of title.

### DIFF
--- a/gallery/styles/_example.scss
+++ b/gallery/styles/_example.scss
@@ -2,6 +2,8 @@
 // ==========================================================================
 // Fix grid layout within example boxes for IE7 and below
 // where box-sizing isn't supported: http://caniuse.com/#search=box-sizing
+@import "measurements";
+
 @mixin example-box-column($width) {
   width: (($site-width - $gutter) * $width) - $gutter;
 }

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -3,7 +3,7 @@ const paths = require('../paths')
 const gulpSequence = require('gulp-sequence')
 
 gulp.task('watch', (done) => {
-  gulpSequence('build', 'serve', 'browserSync', () => {
+  gulpSequence('clean', 'nunjucks', 'sass', 'css', 'webpack', 'images', 'serve', 'browserSync', () => {
     gulp.watch([`${paths.projectDir}/src/components/**/*.js`, `${paths.projectDir}/src/javascripts/**/*.js`], ['webpack'])
     gulp.watch(`${paths.projectDir}/src/**/*.scss`, ['sass', 'css'])
     gulp.watch(`${paths.imagesSource}/**/*`, ['images'])

--- a/src/components/searchbar/_searchbar.scss
+++ b/src/components/searchbar/_searchbar.scss
@@ -50,9 +50,8 @@
 
 .searchbar.searchbar--header {
   width: 90%;
-  margin: 10px auto;
-  padding-left: 0;
-  padding-right: 0;
+  margin: 10px 0;
+  padding: 0;
 
   @include media(tablet) {
     float: right;
@@ -66,8 +65,9 @@
 
   .searchbar__input {
     border: 0;
-    font-size: em(16);
+    font-size: em(18);
     line-height: 22px;
+    padding: 8px 15px 4px;
   }
 
   .searchbar__submit {

--- a/src/nunjucks/layouts/ukti_template.html
+++ b/src/nunjucks/layouts/ukti_template.html
@@ -39,14 +39,7 @@
 
     <header role="banner" id="global-header" class="global-header--govuk with-proposition" >
       <div class="header-wrapper">
-        <div class="header-global">
-          <div class="header-logo">
-            <a href="{{ root_url | default('/') }}" title="Home link" id="logo" class="content">
-              <img src="{{ asset_path | default('/') }}images/gov.uk_logotype_crown_invert_trans.png" width="35" height="31" alt="Crown logo">
-              {% block service_name %}{% endblock %}
-            </a>
-          </div>
-        </div>
+        <a href="{{ root_url | default('/') }}" title="Home link" class="header-global">{% block service_name %}{% endblock %}</a>
         <div class="top-menu">{% block top_menu %}{% endblock %}</div>
       </div>
     </header>

--- a/src/sass/trade/govuk/_header.scss
+++ b/src/sass/trade/govuk/_header.scss
@@ -5,64 +5,18 @@
 @import "typography";
 @import "colours";
 
-#global-header.global-header--govuk {
+#global-header{
   background-color: $black;
-  width: 100%;
 
   .header-wrapper {
-    background-color: $black;
-    max-width: 990px;
-    margin: 0 auto;
-    padding-top: 8px;
-    padding-bottom: 8px;
-    @extend %contain-floats;
-    @include media(tablet) {
-      padding-left: $gutter-half;
-      padding-right: $gutter-half;
-    }
-    @include ie-lte(8) {
-      width: 990px;
-    }
-
-    .header-global {
-      @extend %contain-floats;
-      @include media(tablet) {
-        display: inline-block;
-        float: left;
-        width: 50%;
-      }
-
-      .header-logo {
-        @extend %contain-floats;
-
-        .content {
-          margin: 0 15px;
-        }
-      }
-
-      .header-logo {
-        margin: 5px 0 2px;
-      }
-    }
-
-    .top-menu {
-      @include media(tablet) {
-        display: inline-block;
-        float: right;
-        width: 50%;
-      }
-    }
-
+    @extend %site-width-container;
+    padding: 8px 0;
   }
-
-  #logo {
-    float: left;
-    position: relative;
-    top: -1px;
-
-    height: 30px;
-    overflow: visible;
-    vertical-align: baseline;
+  .header-global {
+    @include media(tablet) {
+      display: inline-block;
+      margin: 5px 0 2px;
+    }
 
     color: $white;
     font-weight: bold;
@@ -74,34 +28,18 @@
     padding-top: 2px;
     border-bottom: 1px solid transparent;
 
-    background: url("#{$asset-path}images/gov.uk_logotype_crown.png") no-repeat;
-    background-size: 35px 31px;
-    background-position: 0 0;
-    @include ie-lte(8) {
-      background-image: url("#{$assetPath}gov.uk_logotype_crown-1x.png");
-    }
-
-    img {
-      position: relative;
-      top: -2px;
-      padding-right: 6px;
-      display: inline;
-      line-height: inherit;
-      border: none;
-      visibility: hidden;
-    }
-
     &:hover,
     &:focus {
       text-decoration: none;
       border-bottom-color: $white;
     }
   }
-
   .top-menu {
-    padding-top: 10px;
-    @include media(desktop) {
-      padding-top: 0;
+    @include media(tablet) {
+      display: inline-block;
+      float: right;
+      width: 50%;
+      padding-top: 4px;
     }
 
     a {
@@ -140,9 +78,6 @@
   @extend %site-width-container;
   height: 10px;
   background-color: $govuk-blue;
-  @include ie-lte(8) {
-    font-size: 0;
-  }
 }
 
 // Global cookie message


### PR DESCRIPTION
Simplified the markup and remove a bunch of css not needed.

Tested on IE8,9,10,11,Edge, Firefox and chrome. Also ios and chrome mobile