### PR TITLE
IE11 and below require a polyfill for some ES6 functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,6 @@
 # 3.0.0
 - Change header style to new simpler header with no crown
 - Disabled revision tools in develop mode
+
+# 3.0.1
+- Fix support for IE11 and below by including polyfill

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uktrade/trade_elements",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Pattern library with styles, templates and js to create UKTI Trade and internal sites and services",
   "repository": {
     "type": "git",

--- a/src/javascripts/cookie.js
+++ b/src/javascripts/cookie.js
@@ -65,8 +65,8 @@
   if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
 
   GOVUK.addCookieMessage = function () {
-    const message = document.getElementById('global-cookie-message')
-    const hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null)
+    var message = document.getElementById('global-cookie-message')
+    var hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null)
 
     if (hasCookieMessage) {
       message.style.display = 'block'
@@ -84,16 +84,16 @@
 
   // header navigation toggle
   if (document.querySelectorAll && document.addEventListener) {
-    const els = document.querySelectorAll('.js-header-toggle')
-    let i
-    let _i
+    var els = document.querySelectorAll('.js-header-toggle')
+    var i
+    var _i
 
     for (i = 0, _i = els.length; i < _i; i++) {
       els[i].addEventListener('click', function (e) {
         e.preventDefault()
-        const target = document.getElementById(this.getAttribute('href').substr(1))
-        const targetClass = target.getAttribute('class') || ''
-        const sourceClass = this.getAttribute('class') || ''
+        var target = document.getElementById(this.getAttribute('href').substr(1))
+        var targetClass = target.getAttribute('class') || ''
+        var sourceClass = this.getAttribute('class') || ''
 
         if (targetClass.indexOf('js-visible') !== -1) {
           target.setAttribute('class', targetClass.replace(/(^|\s)js-visible(\s|$)/, ''))

--- a/src/javascripts/trade-elements-components.js
+++ b/src/javascripts/trade-elements-components.js
@@ -1,5 +1,6 @@
 // Can clash with react version of radion. need to investigate
 // require('../components/radio/radio')
+require('babel-polyfill')
 require('../components/autocomplete/autocompleteselect')
 require('../components/autocomplete/autocompleteajax')
 require('../components/flashmessage/flash-message')


### PR DESCRIPTION
Adding the polyfill include brings in a whole bunch of stuff designed to polyfill missing JS stuff on browsers such as IE11 and below.