### PR TITLE
Keep running into an issue where if a project includes trade elements and babel polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,6 @@
 
 # 3.0.1
 - Fix support for IE11 and below by including polyfill
+
+# 3.1.0
+- Split out polyfill so that it fixes clashes with including polyfill in child projects.

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -10,6 +10,9 @@ gulp.task('webpack', done => {
       gulp.src(`${paths.sourceJS}/cookie.js`)
         .pipe(gulp.dest(paths.outputJS))
 
+      gulp.src(`${paths.node_modules}/babel-polyfill/dist/polyfill.min.js`)
+        .pipe(gulp.dest(`${paths.outputJS}`))
+
       gulp.src(`${paths.sourceJS}/lib/**/*.js`)
         .pipe(gulp.dest(`${paths.outputJS}/lib`))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uktrade/trade_elements",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Pattern library with styles, templates and js to create UKTI Trade and internal sites and services",
   "repository": {
     "type": "git",

--- a/src/javascripts/trade-elements-components.js
+++ b/src/javascripts/trade-elements-components.js
@@ -1,10 +1,8 @@
 // Can clash with react version of radion. need to investigate
 // require('../components/radio/radio')
-require('babel-polyfill')
 require('../components/autocomplete/autocompleteselect')
 require('../components/autocomplete/autocompleteajax')
 require('../components/flashmessage/flash-message')
 require('../components/horizontaltabs/tab')
 require('../components/radio/radio')
-
 require('../components/table/tablesort').activateAll()

--- a/src/nunjucks/layouts/ukti_template.html
+++ b/src/nunjucks/layouts/ukti_template.html
@@ -76,6 +76,9 @@
       </footer>
     {% endblock %}
 
+    <!--[if lt IE 11]>
+    <script src="{{ asset_path | default('/') }}javascripts/polyfill.min.js"></script>
+    <![endif]-->
     <script src="{{ asset_path | default('/') }}javascripts/cookie.js"></script>
     <script src="{{ asset_path | default('/') }}javascripts/trade-elements-components.js"></script>
     {% block body_end %}{% endblock %}


### PR DESCRIPTION
If a dependant project includes babel polyfill this produces an error. Split Polyfill out so it’s optionally included as a separate file on it’s own and only pulled in for the browsers that need it.