### PR TITLE
Fix ie10 compatbility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,5 +99,11 @@
 # 3.0.1
 - Fix support for IE11 and below by including polyfill
 
-# 3.1.0
+# 3.0.2
 - Split out polyfill so that it fixes clashes with including polyfill in child projects.
+
+# 3.0.3
+- Fix issue with IE browser detection as not supported >= IE10
+- Switch from polyfill to babel-runtime to avoid side effects
+- Remove dependency on Array.prototype.includes as not supported in IE <= 11
+- Improve rendering of searchbar on IE by using padding instead of line-height

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.18.0",
     "browser-sync": "^2.18.5",
     "chai": "^3.5.0",
     "compression": "^1.6.2",
     "del": "^2.2.2",
+    "es6-promise": "^4.1.0",
     "eslint": "^3.12.2",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",
@@ -63,6 +65,7 @@
     "moment": "^2.17.1",
     "nunjucks": "^3.0.0",
     "prismjs": "^1.6.0",
+    "proxyquire": "^1.7.11",
     "require-dir": "^0.3.1",
     "standard": "^8.6.0",
     "webpack": "^1.14.0"
@@ -87,7 +90,6 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.15.3",
-    "proxyquire": "^1.7.11"
+    "axios": "^0.15.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uktrade/trade_elements",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Pattern library with styles, templates and js to create UKTI Trade and internal sites and services",
   "repository": {
     "type": "git",

--- a/src/components/autocomplete/autocompleteajax.js
+++ b/src/components/autocomplete/autocompleteajax.js
@@ -1,4 +1,4 @@
-/* eslint no-useless-escape: 0, no-new: 0 */
+/* eslint no-useless-escape: 0, no-new: 0, handle-callback-err: 0 */
 require('es6-promise').polyfill()
 const axios = require('axios')
 const debounce = require('lodash/debounce')

--- a/src/components/autocomplete/autocompleteajax.js
+++ b/src/components/autocomplete/autocompleteajax.js
@@ -1,4 +1,5 @@
 /* eslint no-useless-escape: 0, no-new: 0 */
+require('es6-promise').polyfill()
 const axios = require('axios')
 const debounce = require('lodash/debounce')
 const AutocompleteBase = require('./autocompletebase')

--- a/src/components/autocomplete/autocompletebase.js
+++ b/src/components/autocomplete/autocompletebase.js
@@ -1,5 +1,14 @@
 /* eslint no-useless-escape: 0, no-new: 0 */
 const { addClass, removeClass, insertAfter, findDoc, createElementFromMarkup } = require('../../javascripts/lib/elementstuff')
+const eventsToSuppress = [40, 38, 9, 13, 27]
+
+function arrayIncludes (array, item) {
+  if (!Array.isArray(array)) {
+    return false
+  }
+
+  return array.indexOf(item)
+}
 
 class AutocompleteBase {
   constructor (element) {
@@ -134,7 +143,7 @@ class AutocompleteBase {
   }
 
   keyDown = (event) => {
-    this.suppressKeyPressRepeat = [40, 38, 9, 13, 27].includes(event.keyCode)
+    this.suppressKeyPressRepeat = arrayIncludes(eventsToSuppress, event.keyCode)
     this.move(event)
   }
 

--- a/src/components/searchbar/_searchbar.scss
+++ b/src/components/searchbar/_searchbar.scss
@@ -20,13 +20,12 @@
     box-sizing: border-box;
     font-size: em(19);
     width: 100%;
-    padding: 6px 15px;
+    padding: 10px 15px;
     margin: 0;
     z-index: 3;
     background: transparent;
     position: relative;
     border-right: 0;
-    line-height: 34px;
     border-radius: 0;
     -webkit-appearance: none;
     text-overflow: ellipsis;
@@ -65,9 +64,8 @@
 
   .searchbar__input {
     border: 0;
-    font-size: em(18);
-    line-height: 22px;
-    padding: 8px 15px 4px;
+    font-size: 16px;
+    padding: 6px 15px;
   }
 
   .searchbar__submit {

--- a/src/nunjucks/layouts/ukti_template.html
+++ b/src/nunjucks/layouts/ukti_template.html
@@ -76,9 +76,6 @@
       </footer>
     {% endblock %}
 
-    <!--[if lt IE 11]>
-    <script src="{{ asset_path | default('/') }}javascripts/polyfill.min.js"></script>
-    <![endif]-->
     <script src="{{ asset_path | default('/') }}javascripts/cookie.js"></script>
     <script src="{{ asset_path | default('/') }}javascripts/trade-elements-components.js"></script>
     {% block body_end %}{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = [
             cacheDirectory: './babel_cache',
             babelrc: false,
             presets: ['es2015'],
-            plugins: ['transform-class-properties']
+            plugins: ['transform-class-properties', 'transform-runtime']
           }
         }
       ]


### PR DESCRIPTION
Move from polyfill to babel-runtime following advice that polyfill should not be used in libraries, which seems sensible.

Removed usage of Array.prototype.includes to work with IE10.
Realised that line heights on inputs doesn't work so well on IE11 and below, even though .gov.uk uses it.